### PR TITLE
Remove `postinstall` script altogether

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,10 @@
     "node": ">=14.0"
   },
   "scripts": {
-    "//": "#use npx here to ensure that non-TS users triggering the postinstall script don't need to install TypeScript globally or in their project",
-    "build": "npx -p typescript tsc --build tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "clean": "git clean -dfqX",
     "install-with-npm-8.5": "npm i -g npm@^8.5.0 && npm i",
-    "postinstall": "npm run build",
+    "prepack": "npm run build",
     "prettier-check": "prettier --check .",
     "prettier-fix": "prettier --write .",
     "publish-changeset": "changeset publish",


### PR DESCRIPTION
After a couple iterations, I've decided the best approach to this is to make sure the project is never built when installed into a project.

The `postinstall` script is a small convenience for local development such that a build is performed after cloning and running `npm install` in this repo. Relatedly, our publishing steps also depended on the build that happened due to the execution of this script.

The previous workaround (#83 + #84) was insufficient because while it dropped the requirement of the host project to have `typescript` installed, it still required various `@types/` packages to be installed, so the solution was insufficient and still caused errors for non-TS users installing this package (really, packages that scaffold off this template).

The hope was to preserve behavior that when this project is cloned and installed, a build would be performed. I don't see a nice way to accomplish this without also having the effect of running the `build` script when this package is installed into another project.

The `prepare` script was considered as well, but that script is called both for transitive and local installs which is what we want to avoid.

The `prepack` script is necessary for CI / publish steps to ensure the build is completed before publishing to NPM. (a learning from https://github.com/apollographql/datasource-rest/pull/57)