### PR TITLE
Update codesandbox ci usage

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,4 @@
 {
   "sandboxes": [],
-  "node": "16",
-  "installCommand": "install-with-npm-8.5"
+  "node": "18"
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "clean": "git clean -dfqX",
-    "install-with-npm-8.5": "npm i -g npm@^8.5.0 && npm i",
     "prepack": "npm run build",
     "prettier-check": "prettier --check .",
     "prettier-fix": "prettier --write .",


### PR DESCRIPTION
Remove workaround for workspaces and update node version of CS:CI container now that v18 is supported.