### PR TITLE
adjustments to npm publish workflow for OIDC publishing

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -22,10 +22,10 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup Node.js 18.x
+      - name: Setup Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 24.x
 
       - name: Install Dependencies
         run: npm i
@@ -36,4 +36,4 @@ jobs:
           publish: npm run publish-changeset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ""

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For proper CHANGELOG management, you MUST configure the [`.changeset/config.json
 
 ### NPM Publishing
 
-Changesets manages and updates a release PR automatically via a GitHub action [`.github/workflows/release-pr.yml`](.github/workflows/release-pr.yml). The PR consumes all of the committed changesets on `main` in order to bump versions of packages and update the `CHANGELOG` accordingly. Merging this PR will result in publishes to npm IF you've provided an `NPM_TOKEN` as a secret to your repo's GitHub actions (`https://github.com/apollographql/<repo-name>/settings/secrets/actions`). Please reach out to anyone in the `#npm-apollo-bot-owners` Slack channel for a token. Changesets will also publish a GitHub release when this PR is merged.
+Changesets manages and updates a release PR automatically via a GitHub action [`.github/workflows/release-pr.yml`](.github/workflows/release-pr.yml). The PR consumes all of the committed changesets on `main` in order to bump versions of packages and update the `CHANGELOG` accordingly. Merging this PR will result in publishes to npm IF you correctly configured the package's OpenIDConnect section in the npm repository settings.
 
 > Our action borrows directly from the action provided by `changesets`. Visit [the changesets action repo](https://github.com/changesets/action) for more info.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/apollographql/typescript-repo-template"
+    "url": "git+https://github.com/apollographql/typescript-repo-template.git"
   },
   "homepage": "https://github.com/apollographql/typescript-repo-template#readme",
   "bugs": {


### PR DESCRIPTION
This PR makes changes to enable OIDC publishing to npm, so that we no longer need to use npm tokens stored in GitHub secrets.

It makes the following changes:
 * Update the `repository` field in `package.json` files to the format that `npm` expects here - via `npm pkg fix`
 * Add permissions required for OIDC publishing to the GitHub Actions workflow
 * Ensures that the node version for publishing is node 24. `npm` versions shipping with older node versions cannot publish via OIDC. Some node 22 versions can, but it's a gamble and hard to debug if something goes wrong.
 * Remove references to `NPM_TOKEN` secrets in the GitHub Actions workflow - or if using changesets, sets it to `""` as changesets requires the env var to be set, but actually doesn't do anything - and it should be empty for OIDC publishing to work.
 
 I have already gone ahead and set OIDC publishing on the npm side, so this is just the second half of the puzzle.